### PR TITLE
Add support for ED25519 scalar multiplication

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -215,6 +215,7 @@ LIBSODIUM_SRCS-y += $(LIBSODIUM_EXTRACTED)/src/libsodium/sodium/core.c
 LIBSODIUM_SRCS-y += $(LIBSODIUM_EXTRACTED)/src/libsodium/sodium/runtime.c
 LIBSODIUM_SRCS-y += $(LIBSODIUM_EXTRACTED)/src/libsodium/sodium/utils.c
 LIBSODIUM_SRCS-y += $(LIBSODIUM_EXTRACTED)/src/libsodium/sodium/version.c
+LIBSODIUM_SRCS-y += $(LIBSODIUM_EXTRACTED)/src/libsodium/crypto_scalarmult/ed25519/ref10/scalarmult_ed25519_ref10.c
 
 ################################################################################
 # sodium tests

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -216,6 +216,7 @@ LIBSODIUM_SRCS-y += $(LIBSODIUM_EXTRACTED)/src/libsodium/sodium/runtime.c
 LIBSODIUM_SRCS-y += $(LIBSODIUM_EXTRACTED)/src/libsodium/sodium/utils.c
 LIBSODIUM_SRCS-y += $(LIBSODIUM_EXTRACTED)/src/libsodium/sodium/version.c
 LIBSODIUM_SRCS-y += $(LIBSODIUM_EXTRACTED)/src/libsodium/crypto_scalarmult/ed25519/ref10/scalarmult_ed25519_ref10.c
+LIBSODIUM_SRCS-y += $(LIBSODIUM_EXTRACTED)/src/libsodium/crypto_core/ed25519/core_ed25519.c
 
 ################################################################################
 # sodium tests


### PR DESCRIPTION
Add libsodium reference implementation in `scalarmult_ed25519_ref10.c`.