### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "libsodium"
+description := "A modern, portable, easy to use crypto library."
+gitrepo     := "https://github.com/jedisct1/libsodium.git"
+homepage    := "https://doc.libsodium.org/"
+version     := 1.0.18 sha256:d59323c6b712a1519a5daf710b68f5e7fde57040845ffec53850911f10a5d4f4 https://github.com/jedisct1/libsodium/archive/1.0.18.tar.gz
+license     := "ISC"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

